### PR TITLE
enhancement: Added Resource Group ID to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_private_dns_zones"></a> [private\_dns\_zones](#output\_private\_dns\_zones) | object with all created Private DNS Zones |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | ID of the Resource Group created by the module |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "private_dns_zones" {
   description = "object with all created Private DNS Zones"
   value       = azurerm_private_dns_zone.this
 }
+
+output "resource_group_id" {
+  description = "ID of the Resource Group created by the module"  
+  value       = azurerm_resource_group.this.id
+}


### PR DESCRIPTION

💡 Summary of the pull request
I have added one extra output - Resource Group ID

🛠️ Implementation Details
Added the ID of the Resource Group deployed by the module to the list of Terraform outputs

📝 Additional Information
Required to support RG-level locks created in consuming deployments.

