### PR TITLE
bug: remove monitoring as it can break functionality

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -58,7 +58,6 @@ locals {
         "privatelink.azure-automation.net",
         "privatelink.${var.shortlocation}.backup.windowsazure.com",
         "privatelink.siterecovery.windowsazure.com",
-        "privatelink.monitor.azure.com",
         "privatelink.oms.opinsights.azure.com",
         "privatelink.ods.opinsights.azure.com",
         "privatelink.agentsvc.azure-automation.net",


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
* remove "privatelink.monitor.azure.com"

**:rocket: Motivation**
* breaks connection to "dc.services.visualstudio.com"

**:pencil: Additional Information**
* If needed can be manually re-added
