### PR TITLE
remove kubernetesconfiguration private dns zone

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -42,7 +42,6 @@ locals {
         "privatelink.redisenterprise.cache.azure.net",
         "privatelink.his.arc.azure.com",
         "privatelink.guestconfiguration.azure.com",
-        "privatelink.dp.kubernetesconfiguration.azure.com",
         "privatelink.eventgrid.azure.net",
         "privatelink.ts.eventgrid.azure.net",
         "privatelink.azure-api.net",


### PR DESCRIPTION
There will be no records in it, and it causes flux extension installation to fail

**:hammer_and_wrench: Summary**
<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
