### PR TITLE
fix: Bump terraform provder version to minimum supported for azurerm_private_dns_zone_virtual_network_link.resolution_policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Terraform Module to create all privatelink dns zones
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4, < 5.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.36, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4, < 5.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 4.36, < 5.0 |
 
 ## Modules
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4, < 5.0"
+      version = ">= 4.36, < 5.0"
     }
   }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Increase minimum azurerm version to support the resolution_policy argument
## :rocket: Motivation
Current version is broken with older provider version
